### PR TITLE
Update README for S/C helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ js-helper-library/
 ├── extensions/ → Native object extensions (e.g., Array.prototype)
 │   └── array.js
 ├── helpers/ → Standalone utility functions
-│   ├── dom-helper.js → $(), £(), addExtensions()
+│   ├── dom-helper.js → S(), C(), div(), p(), addExtensions()
 │   └── utilities.js → General-purpose small helpers
 ├── modules/ → Self-contained modules
 │   └── service-call.js → API/fetch helpers
@@ -28,9 +28,9 @@ import './extensions/array.js';
 const nums = [1, 2, 2, 3];
 console.log(nums.unique().first()); // [1, 2, 3] → 1
 
-import { £, $ } from './helpers/dom-helper.js';
+import { C, S } from './helpers/dom-helper.js';
 
-£('div')
+C('div')
   .addClass('box')
   .attr('id', 'main')
   .appendTo(document.body);


### PR DESCRIPTION
## Summary
- update README references from `$`/`£` to `S`/`C`
- update usage example to use new helpers

## Testing
- `grep -n "$()" -n README.md`
- `grep -n "\£()" -n README.md`

------
https://chatgpt.com/codex/tasks/task_e_68531da1fa94832ab8dfa8dd9ea468a3